### PR TITLE
Changed all goadesign occurencies with keitaroinc

### DIFF
--- a/utils/healthcheck/healthcheck.go
+++ b/utils/healthcheck/healthcheck.go
@@ -1,23 +1,23 @@
 package healthcheck
 
 import (
-		"context"
-		"net/http"
+	"context"
+	"net/http"
 
-		"github.com/goadesign/goa"
+	"github.com/keitaroinc/goa"
 )
 
 func NewCheckMiddleware(healthcheckEndpoint string) goa.Middleware {
-		return func(h goa.Handler) goa.Handler {
-				return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-						// Healthcheck endpoint
-						if (req.URL.Path == healthcheckEndpoint) {
-								rw.Header().Set("Content-Type", "application/text")
-								rw.Write([]byte("OK"))	
-								rw.WriteHeader(200)	
-								return nil		
-						}
-						return h(ctx, rw, req)
-				}
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			// Healthcheck endpoint
+			if req.URL.Path == healthcheckEndpoint {
+				rw.Header().Set("Content-Type", "application/text")
+				rw.Write([]byte("OK"))
+				rw.WriteHeader(200)
+				return nil
+			}
+			return h(ctx, rw, req)
 		}
-}	
+	}
+}

--- a/utils/version/version.go
+++ b/utils/version/version.go
@@ -1,11 +1,11 @@
 package version
 
 import (
-		"context"
-		"net/http"
-		"encoding/json"
+	"context"
+	"encoding/json"
+	"net/http"
 
-		"github.com/goadesign/goa"
+	"github.com/keitaroinc/goa"
 )
 
 type Read struct {
@@ -18,20 +18,19 @@ func NewVersionMiddleware(version, versionEndpoint string) goa.Middleware {
 
 			endpoints := Read{version}
 			js, err := json.Marshal(endpoints)
-			
+
 			if err != nil {
 				http.Error(rw, err.Error(), http.StatusInternalServerError)
 				return err
-			}	
+			}
 			// Endpoint that returns the microservice version
-			if (req.URL.Path == versionEndpoint) {
-					rw.Header().Set("Content-Type", "application/json")
-					rw.Write(js)		
-					rw.WriteHeader(200)	
-					return nil
+			if req.URL.Path == versionEndpoint {
+				rw.Header().Set("Content-Type", "application/json")
+				rw.Write(js)
+				rw.WriteHeader(200)
+				return nil
 			}
 			return h(ctx, rw, req)
 		}
 	}
 }
-	


### PR DESCRIPTION
In compliance with the latest issue with the official goadesign repo changing its default branch and version, none of the microservices can work properly. By using keitaroinc's fork, we can make sure nothing breaks until we migrate the microservices to the latest goadesign version.